### PR TITLE
Pass the series and point to the labelFormatter

### DIFF
--- a/jquery.flot.valuelabels.js
+++ b/jquery.flot.valuelabels.js
@@ -264,7 +264,7 @@
                         });
                     }
                     val = "" + val;
-                    val = labelFormatter(val);
+                    val = labelFormatter(val, {series: series, point: series.data[i]});
 
                     if (!hideSame || val != last_val || i == series.data.length - 1) {
                         // if bar is too small to show value inside, show it outside


### PR DESCRIPTION
This enables more sophisticated formatting based on what series the point is in etc. 

I've found I wanted this in a few situations where I'd like to be able to make decisions as to how to render the text depending on the relative value compared to the x or y-axis etc; I've also found it handy to be able to output data that isn't stored within the graph (annotations for example) from external arrays of data etc