### PR TITLE
Fix for #13

### DIFF
--- a/jquery.flot.valuelabels.js
+++ b/jquery.flot.valuelabels.js
@@ -292,7 +292,7 @@
                             }
                             addstack = stacked[stackedIndex];
                             stacked[stackedIndex] = stacked[stackedIndex] + y;
-                            if (!series.valueLabels.show) return;
+                            if (!series.valueLabels.show) continue;
                         }
 
                         xx = series.xaxis.p2c(x) + plot.getPlotOffset().left;

--- a/jquery.flot.valuelabels.js
+++ b/jquery.flot.valuelabels.js
@@ -85,7 +85,7 @@
             var pointDelta;
 
             $.each(plot.getData(), function(ii, series) {
-                if (!series.valueLabels.show) return;
+                if (!series.valueLabels.show && !series.stack) return;
                 var showLastValue = series.valueLabels.showLastValue;
                 var showMaxValue = series.valueLabels.showMaxValue;
                 var showMinValue = series.valueLabels.showMinValue;
@@ -292,6 +292,7 @@
                             }
                             addstack = stacked[stackedIndex];
                             stacked[stackedIndex] = stacked[stackedIndex] + y;
+                            if (!series.valueLabels.show) return;
                         }
 
                         xx = series.xaxis.p2c(x) + plot.getPlotOffset().left;


### PR DESCRIPTION
We still need to add to the running total even if the current series isn't having the valueLabel displayed if it's stacked so the heights continue to match